### PR TITLE
chore: 파일 타입 밸리데이션 삭제

### DIFF
--- a/middlewares/uploadFiles.js
+++ b/middlewares/uploadFiles.js
@@ -15,11 +15,6 @@ const uploadFiles = multer({
     key: function (req, file, cb) {
       try {
         const fileType = file.mimetype.split("/")[0];
-
-        if (fileType !== "image" && fileType !== "audio") {
-          return cb(new Error(`Not ${fileType}`));
-        }
-
         const fileNameArray = file.originalname.split(".");
 
         cb(


### PR DESCRIPTION
**구현 내용**
핸드폰에서 파일을 올렸을 때 올라가지 않는 오류가 있어 
백엔드 파일타입 밸리데이션 로직을 프론트엔드로 옮겼습니다.
확인 후 다시 수정해야합니다.